### PR TITLE
US374: Search for assets in map view based on viewport bounds

### DIFF
--- a/backend/routes/assets.routes.js
+++ b/backend/routes/assets.routes.js
@@ -218,11 +218,27 @@ router.get("/", async (req, res, err) => {
     aggregateArray.push(locationUnwind);
 
     if(req.query.mapView==="true"){
-      const boundsArray=decodeURI(bounds).split(',');
-      const inBounds= Assets.find( {
-        $geoWithin: { $box: [boundsArray[0],boundsArray[1]]}
-      })
+      const boundsArray=(decodeURI(req.query.mapBounds).split(','));
+      const inBounds={
+         $match: {
+        "deployedLocation.coordinates":{
+          $geoWithin: {
+            //array comes in with [lat,long] but needs to be [long,lat]
+             $box: [[parseFloat(boundsArray[1]),parseFloat(boundsArray[0])],
+                    [parseFloat(boundsArray[3]),parseFloat(boundsArray[2])]]
+                  }
+                }
+              }
+            };
       aggregateArray.push(inBounds);
+    }else {
+      const match = {
+        $match: {
+
+        }
+      };
+
+      aggregateArray.push(match);
     }
 
     if (req.query.sort_by) {

--- a/backend/routes/assets.routes.js
+++ b/backend/routes/assets.routes.js
@@ -21,7 +21,7 @@ router.get("/", async (req, res, err) => {
       const query = req.query;
 
       //remove page, limit, search, and sorting params since they do not go in the $match
-      const disallowed = ["page", "limit", "search", "sort_by", "order"];
+      const disallowed = ["page", "limit", "search", "sort_by", "order","mapBounds","mapView"];
       const filters = await Object.keys(query)
         .reduce(async (pc, c) => {
           const p = await pc;
@@ -216,6 +216,14 @@ router.get("/", async (req, res, err) => {
 
     aggregateArray.push(lookup);
     aggregateArray.push(locationUnwind);
+
+    if(req.query.mapView==="true"){
+      const boundsArray=decodeURI(bounds).split(',');
+      const inBounds= Assets.find( {
+        $geoWithin: { $box: [boundsArray[0],boundsArray[1]]}
+      })
+      aggregateArray.push(inBounds);
+    }
 
     if (req.query.sort_by) {
       //default ascending order

--- a/backend/routes/assets.routes.js
+++ b/backend/routes/assets.routes.js
@@ -181,6 +181,35 @@ router.get("/", async (req, res, err) => {
       aggregateArray.push(match);
     }
 
+    let deployedLookup = {
+      $lookup: {
+          'from': Location.collection.name,
+          let: { deployedId: "$deployedLocation" },
+          pipeline: [
+              {
+                  $match: {
+                      $expr: {
+                          $eq: ["$_id", "$$deployedId"],
+                      }
+                  }
+
+              }, {
+                  $project: {
+                      _id: 0,
+                      __v: 0
+                  }
+              }
+          ],
+          'as': "deployedLocation"
+      }
+  };
+
+  const deployedUnwind = {
+      $unwind: {
+          path: "$deployedLocation"
+      }
+  };
+
     if (req.query.sort_by) {
       //default ascending order
       const sortOrder = (req.query.order === 'desc' ? -1 : 1);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-geocode": "^0.2.3",
         "react-leaflet": "^2.8.0",
         "react-leaflet-curve": "^2.0.1",
+        "react-leaflet-markercluster": "^2.0.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.0",
         "react-uuid": "^1.0.2",
@@ -12218,6 +12219,15 @@
         "leaflet": ">=0.7.0"
       }
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.0.tgz",
+      "integrity": "sha512-Fvf/cq4o806mJL50n+fZW9+QALDDLPvt7vuAjlD2vfnxx3srMDs2vWINJze4nKYJYRY45OC6tM/669C3pLwMCA==",
+      "peer": true,
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15805,6 +15815,21 @@
         "prop-types": "^15.7.2",
         "react": "^16.12.0",
         "react-leaflet": "^2.5.0"
+      }
+    },
+    "node_modules/react-leaflet-markercluster": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-markercluster/-/react-leaflet-markercluster-2.0.0.tgz",
+      "integrity": "sha512-X1OuaMf4LeAQap638+X46+AN7ZqJKZse84o964brKj4AVVifs4fKCxTTFH6+MoyIarbWvF8x6tJ4vxT2BtxLYg==",
+      "dependencies": {
+        "leaflet": "^1.6.0",
+        "leaflet.markercluster": "^1.4.1",
+        "react-leaflet": "^2.6.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.6.0",
+        "leaflet.markercluster": "^1.4.1",
+        "react-leaflet": "^2.6.3"
       }
     },
     "node_modules/react-refresh": {
@@ -31050,6 +31075,13 @@
         "leaflet": ">=0.7.0"
       }
     },
+    "leaflet.markercluster": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.0.tgz",
+      "integrity": "sha512-Fvf/cq4o806mJL50n+fZW9+QALDDLPvt7vuAjlD2vfnxx3srMDs2vWINJze4nKYJYRY45OC6tM/669C3pLwMCA==",
+      "peer": true,
+      "requires": {}
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -33926,6 +33958,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-leaflet-curve/-/react-leaflet-curve-2.0.1.tgz",
       "integrity": "sha512-bQBhwsBTSkrI49+sLPCQvTBcYKcGzI/mTm1tfxR34ebq2sKjt56VVldZafze+/cAiJSjKMRtvJu1LHxqTDinqw==",
+      "requires": {}
+    },
+    "react-leaflet-markercluster": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-markercluster/-/react-leaflet-markercluster-2.0.0.tgz",
+      "integrity": "sha512-X1OuaMf4LeAQap638+X46+AN7ZqJKZse84o964brKj4AVVifs4fKCxTTFH6+MoyIarbWvF8x6tJ4vxT2BtxLYg==",
       "requires": {}
     },
     "react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-geocode": "^0.2.3",
     "react-leaflet": "^2.8.0",
     "react-leaflet-curve": "^2.0.1",
+    "react-leaflet-markercluster": "^2.0.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "react-uuid": "^1.0.2",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,25 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Product management portal for Evolution Energy"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-        <!-- leaftlet css -->
-        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
-        integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
-        crossorigin=""/>
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Product management portal for Evolution Energy" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!-- leaftlet css -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+    integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+    crossorigin="" />
+  <link rel="stylesheet" href="https://unpkg.com/react-leaflet-markercluster/dist/styles.min.css" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -29,17 +28,18 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-     <!-- leaftlet css -->
-     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
-     integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
-     crossorigin=""/>
-     
-    <title>Product Management Portal | Evolution Energy</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <!-- leaftlet css -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+    integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+    crossorigin="" />
+
+  <title>Product Management Portal | Evolution Energy</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -49,5 +49,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/frontend/src/components/Feedback/WarningIndicator.jsx
+++ b/frontend/src/components/Feedback/WarningIndicator.jsx
@@ -40,7 +40,7 @@ const WarningIndicator = ({ warnings, label }) => {
                     {/* Render out the array of warning strings supplied as props into the tooltip */}
                     <Typography variant="body2"><b>{warnings.length} warning{warnings.length === 1 ? "" : "s"}</b></Typography>
                     {
-                        warnings.map(warning => <Typography variant="body2">{warning}</Typography>)
+                        warnings.map((warning, idx) => <Typography key={idx} variant="body2">{warning}</Typography>)
                     }
                 </React.Fragment>
             }>

--- a/frontend/src/components/SimpleMap.jsx
+++ b/frontend/src/components/SimpleMap.jsx
@@ -138,11 +138,12 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
 
 
     const onViewChanged = () => {
-        console.log("Zoom " + mapRef.current.leafletElement.getZoom());
-        console.log(mapRef.current.leafletElement.getBounds());
-        if (mapRef.current.leafletElement.getZoom() > 10) {
+        if (mapRef.current.leafletElement.getZoom() >= 10) {
             const bounds=mapRef.current.leafletElement.getBounds();
-            onBoundsChanged([bounds.getSouthWest().reverse(),bounds.getNorthEast().reverse()]);
+            const southWest=bounds.getSouthWest();
+            const northEast=bounds.getNorthEast();
+            console.log(mapRef.current.leafletElement.getZoom());
+            onBoundsChanged([southWest.lat,southWest.lng,northEast.lat,northEast.lng]);
         }
     }
 

--- a/frontend/src/components/SimpleMap.jsx
+++ b/frontend/src/components/SimpleMap.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Map, Marker, TileLayer, FeatureGroup, GeoJSON, Popup } from 'react-leaflet';
 import Typography from '@material-ui/core/Typography';
 import L from 'leaflet';
+import MarkerClusterGroup from 'react-leaflet-markercluster';
 
 //Icons
 import ShipFromIcon from './Icons/ShipFromIcon.svg'; //blue icon represents source
@@ -13,6 +14,7 @@ import ShipToIcon from './Icons/ShipToIcon.svg'; //green icon represents destina
 //Library Tools
 import { makeStyles } from '@material-ui/core/styles';
 import bezierSpline from '@turf/bezier-spline'; //for drawing line between the two points
+// eslint-disable-next-line no-unused-vars
 import arrow from "leaflet-arrowheads"; //add arrowheads to line
 
 //Helper Tools
@@ -51,12 +53,14 @@ const shipFromMarkerIcon = new L.Icon({
     className: 'leaflet-marker-shipfrom'
 });
 
-const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
+const SimpleMap = ({ start, end, data, styling, onBoundsChanged = null, variant = null }) => {
     const classes = useStyles();
 
     /* Refs to the map components, used to set bounds and make the two markers fit */
     const mapRef = useRef(null);
     const featureRef = useRef(null);
+
+    const boundsInitialLoadCallback = useRef((bounds) => onBoundsChanged ? onBoundsChanged(bounds) : null); //runs on map mounting so asset list is properly updated
 
     const [refAcquired, setRefAcquired] = useState(false); //true when map components are rendered and refs can be used
     const [center, setCenter] = useState([51, -114]); //center of the map
@@ -69,6 +73,14 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
         setRefAcquired(true);
     }, []);
 
+    /* onBoundsChanged only runs when the map moves, so run it when the map first loads too */
+    useEffect(() => {
+        const bounds = mapRef.current.leafletElement.getBounds();
+        const southWest = bounds.getSouthWest();
+        const northEast = bounds.getNorthEast();
+        boundsInitialLoadCallback.current([southWest.lat, southWest.lng, northEast.lat, northEast.lng]);
+    }, [mapRef, boundsInitialLoadCallback]);
+
     /* Reset the map bounds to ensure both markers fit in the viewport */
     useEffect(() => {
         if (refAcquired) {
@@ -76,18 +88,18 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
                 mapRef.current.leafletElement.fitBounds(featureRef.current.leafletElement.getBounds());
             } catch (err) { }
         }
-    }, [refAcquired, data]);
+    }, [refAcquired]);
 
     /* Centers the popup when it is open, or re-center to fit the two markers when it is closed */
     useEffect(() => {
         if (refAcquired) {
             if (popupPosition) {
                 mapRef.current.leafletElement.setView(coords ? [popupPosition.coords[0] + 5, popupPosition.coords[1]] : popupPosition.coords);
-            } else {
+            } else if (variant !== "search") {
                 mapRef.current.leafletElement.setView(center);
             }
         }
-    }, [center, popupPosition, refAcquired, coords]);
+    }, [center, popupPosition, refAcquired, coords, variant]);
 
     /* Extract the appropriate coordinates and perform line and centering calculations */
     useEffect(() => {
@@ -115,16 +127,16 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
             /* Calculate the center of all the points and set the center of the map */
             if (data.length) {
                 const dataCoords = data.map((obj, idx) => {
-                    /* TODO: Using the index as coords until we can get assets set up with actual coordinates */
                     if (!obj.hasOwnProperty("deployedLocation")) return [0, 0];
                     else if (typeof obj["deployedLocation"] === "string") return [0, 0];
                     else if (typeof obj["deployedLocation"] === "object" && !obj["deployedLocation"].hasOwnProperty("coordinates")) return [0, 0];
                     return [...obj.deployedLocation.coordinates].reverse();
                 });
-                setCenter(findCoordinateAverage(dataCoords));
+
+                if (variant !== "search") setCenter(findCoordinateAverage(dataCoords));
             } else {
                 /* If no data is supplied or last item is deselected, set center back to its original coordinates */
-                setCenter([51, -114]);
+                if (variant !== "search") setCenter([51, -114]);
             }
 
             /* Close the popup when the item it is for is deselected */
@@ -134,17 +146,19 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
             }
         }
 
-    }, [start, end, data, popupPosition]);
+    }, [start, end, data, popupPosition, variant]);
 
-
+    /**
+     * Helper function to return the map bounds using the onBoundsChanged prop function
+     * 
+     * @returns an array of the coordinates of the lower left and upper right bounds of the map view
+     */
     const onViewChanged = () => {
-        if (mapRef.current.leafletElement.getZoom() >= 10) {
-            const bounds=mapRef.current.leafletElement.getBounds();
-            const southWest=bounds.getSouthWest();
-            const northEast=bounds.getNorthEast();
-            console.log(mapRef.current.leafletElement.getZoom());
-            onBoundsChanged([southWest.lat,southWest.lng,northEast.lat,northEast.lng]);
-        }
+        if (!onBoundsChanged) return;
+        const bounds = mapRef.current.leafletElement.getBounds();
+        const southWest = bounds.getSouthWest();
+        const northEast = bounds.getNorthEast();
+        onBoundsChanged([southWest.lat, southWest.lng, northEast.lat, northEast.lng]);
     }
 
     return (
@@ -168,18 +182,20 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
                         </>
                         : data ?
                             <>
-                                {
-                                    data.map((item, idx) => {
-                                        return <Marker
-                                            key={item["serial"]}
-                                            position={
-                                                item["deployedLocation"] ?
-                                                    [...item["deployedLocation"].coordinates].reverse()
-                                                    : [idx, idx]
-                                            }
-                                            onclick={() => setPopupPosition({ coords: item["deployedLocation"] ? [...item["deployedLocation"].coordinates].reverse() : [idx, idx], object: item })} />
-                                    })
-                                }
+                                <MarkerClusterGroup>
+                                    {
+                                        data.map((item, idx) => {
+                                            return <Marker
+                                                key={item["serial"]}
+                                                position={
+                                                    item["deployedLocation"] ?
+                                                        [...item["deployedLocation"].coordinates].reverse()
+                                                        : [idx, idx]
+                                                }
+                                                onclick={() => setPopupPosition({ coords: item["deployedLocation"] ? [...item["deployedLocation"].coordinates].reverse() : [idx, idx], object: item })} />
+                                        })
+                                    }
+                                </MarkerClusterGroup>
                             </>
                             : null
                 }
@@ -268,7 +284,12 @@ SimpleMap.propTypes = {
     /**
      * Array of asset objects to map as markers, each should contain a "deployedLocation" property holding a document with its coordinates where applicable
      */
-    data: PropTypes.array
+    data: PropTypes.array,
+    /**
+     * If variant is not "search" then the map is centered with all markers in view
+     * Setting "search" means the user can drag the map around without it being centered as soon as a marker is found (defeating the purpose of drag-to-search)
+     */
+    variant: PropTypes.string
 }
 
 export default SimpleMap;

--- a/frontend/src/components/SimpleMap.jsx
+++ b/frontend/src/components/SimpleMap.jsx
@@ -143,8 +143,6 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
 
 
     const onViewChanged=() =>{
-        console.log("Zoom "+ mapRef.current.leafletElement.getZoom());
-        console.log(mapRef.current.leafletElement.getBounds());
         if(mapRef.current.leafletElement.getZoom() > 10){
             onBoundsChanged(mapRef.current.leafletElement.getBounds());
         }

--- a/frontend/src/components/SimpleMap.jsx
+++ b/frontend/src/components/SimpleMap.jsx
@@ -141,7 +141,8 @@ const SimpleMap = ({ start, end, data, styling, onBoundsChanged }) => {
         console.log("Zoom " + mapRef.current.leafletElement.getZoom());
         console.log(mapRef.current.leafletElement.getBounds());
         if (mapRef.current.leafletElement.getZoom() > 10) {
-            onBoundsChanged(mapRef.current.leafletElement.getBounds());
+            const bounds=mapRef.current.leafletElement.getBounds();
+            onBoundsChanged([bounds.getSouthWest().reverse(),bounds.getNorthEast().reverse()]);
         }
     }
 

--- a/frontend/src/components/Tables/TableSearchbar.jsx
+++ b/frontend/src/components/Tables/TableSearchbar.jsx
@@ -1,0 +1,76 @@
+import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
+
+//Material-UI Imports
+import InputAdornment from '@material-ui/core/InputAdornment';
+import TextField from '@material-ui/core/TextField';
+import IconButton from '@material-ui/core/IconButton';
+
+//Icons
+import SearchIcon from '@material-ui/icons/Search'
+import ClearIcon from '@material-ui/icons/Clear';
+
+const useStyles = makeStyles({
+    searchbar: {
+        marginTop: "5px",
+        width: "60%"
+    }
+});
+
+const TableSearchbar = ({ onInputChange, onClear, onSearch, disabled = false, searchValue = "" }) => {
+    const classes = useStyles();
+
+    return (
+        <TextField
+            className={classes.searchbar}
+            variant="outlined"
+            size="small"
+            fullWidth
+            disabled={disabled}
+            onChange={onInputChange}
+            value={searchValue}
+            InputProps={{
+                startAdornment: (
+                    <InputAdornment position="start">
+                        <SearchIcon />
+                    </InputAdornment>
+                ),
+                endAdornment: searchValue && (
+                    <InputAdornment position="end">
+                        <IconButton
+                            onClick={onClear}
+                            size="small">
+                            <ClearIcon />
+                        </IconButton>
+                    </InputAdornment>
+                )
+            }}
+            onKeyDown={onSearch}
+        />
+    )
+};
+
+TableSearchbar.propTypes = {
+    /**
+     * onChange handler
+     */
+    onInputChange: PropTypes.func.isRequired, 
+    /**
+     * Textbox clear handler
+     */
+    onClear: PropTypes.func.isRequired, 
+    /**
+     * onKeyDown handler, usually for 'Enter'
+     */
+    onSearch: PropTypes.func.isRequired, 
+    /**
+     * Disable textbox
+     */
+    disabled: PropTypes.bool, 
+    /**
+     * Textbox input value
+     */
+    searchValue: PropTypes.string
+}
+
+export default TableSearchbar;

--- a/frontend/src/components/Tables/TableToolbar.jsx
+++ b/frontend/src/components/Tables/TableToolbar.jsx
@@ -54,21 +54,25 @@ const EnhancedTableToolbar = (props) => {
                 [classes.highlight]: numSelected > 0,
             })}
         >
-            
+
             {numSelected > 0 ? (
                 <Typography className={classes.title} color="inherit" variant="subtitle1" component="div" align='right'>
                     {numSelected} selected
                 </Typography>
             ) : (
                 <>
-                {children.props.children[0]}
-                    <Typography className={classes.title} variant="h6" id="tableTitle" component="div" align='right'>
-                        {title}
-                    </Typography>
-                    </>
-                )}
+                    {children.props.children[0]}
+                    {
+                        title && (
+                            <Typography className={classes.title} variant="h6" id="tableTitle" component="div" align='right'>
+                                {title}
+                            </Typography>
+                        )
+                    }
+                </>
+            )}
 
-            { numSelected > 0 ? children : children.props.children.length > 1 ? children.props.children.slice(1) : children.props.children }
+            { numSelected > 0 ? children : children.props.children.length > 1 ? children.props.children.slice(1) : children.props.children}
 
 
         </Toolbar>

--- a/frontend/src/pages/AllAssets.jsx
+++ b/frontend/src/pages/AllAssets.jsx
@@ -213,6 +213,7 @@ const AllAssets = (props) => {
                                 onBoundsChanged={(bounds)=>{
                                     const mapView="true";
                                     const mapBounds=encodeURI(bounds);
+                                    console.log(bounds);
                                     setFilters(s => ({...s, mapBounds, mapView}))
                                 }}
                                 styling={{ 
@@ -270,7 +271,9 @@ const AllAssets = (props) => {
                                                         <IconButton
                                                             className={map ? classes.disabled : classes.enabled}
                                                             aria-label={"Map-View"}
-                                                            onClick={() => toggleMap(true)}
+                                                            onClick={() => {
+                                                                toggleMap(true)
+                                                             } }
                                                             disabled={map}
                                                         >
                                                             <MapIcon />
@@ -284,7 +287,11 @@ const AllAssets = (props) => {
                                                         <IconButton
                                                             className={!map ? classes.disabled : classes.enabled}
                                                             aria-label={"List-View"}
-                                                            onClick={() => toggleMap(false)}
+                                                            onClick={() => {
+                                                                 toggleMap(false)
+                                                                 const mapView="false"
+                                                                 setFilters(s => ({...s, mapView}))
+                                                            }}
                                                             disabled={!map}
                                                         >
                                                             <ListAltIcon />

--- a/frontend/src/pages/AllAssets.jsx
+++ b/frontend/src/pages/AllAssets.jsx
@@ -211,9 +211,9 @@ const AllAssets = (props) => {
                                 <SimpleMap 
                                 data={assetMarkers} 
                                 onBoundsChanged={(bounds)=>{
-                                    console.log("Bounds changed.");
-                                    console.log(bounds);
-                                    setMapBounds(bounds);
+                                    const mapView="true";
+                                    const mapBounds=encodeURI(bounds);
+                                    setFilters(s => ({...s, mapBounds, mapView}))
                                 }}
                                 styling={{ 
                                     borderRadius: "4px", 


### PR DESCRIPTION
## Overview
This user focused on allowing the asset map view to dynamically search for assets that are deployed to locations within the view of the map. Markers are only displayed if they have coordinates and their coordinates are within the map view. In addition, multiple markers in the same area close together are clustered in a nice way using `react-leaflet-markercluster`.
  
On the backend, a GeoJSON `$geoWithin` query was conditionally added to our main Asset aggregation query. The map component sends out the bounds of the map using the prop function `onBoundsChanged` where the bounds are added to the filter query/URL as `mapBounds` and the API call URL also has a parameter called `mapView` set to `true` in order to invoke the previously mentioned conditional query in the aggregation.
  
On the frontend, the logic got a bit complicated and some changes were made to how the data is handled in the map vs. the list view. I worry there are too many `useEffect`s and that the code is becoming less readable, but it was hard to get everything working together correctly. It may be a good target for a future refactor. I made some UX choices (see Notes section) that may be weird or need changing; please let me know if you see anything you disagree with.

## Developer Pull Request Checklist
- [X] Git worflow defined in QualityPolicy.md has been followed
- [X] This software runs as expected/anticipated
- [X] New and modified code has been tested by an appropriate method (Whitebox/Blackbox)
- [X] All tests passed
  - Manually tested by going through flow and with group Atlas DB and my own Atlas DB instance
- [X] Tests performed have been added to the appropriate testing folder
## Notes
- This US added new dependencies, so be sure to `npm install` before running
- I made some design decisions with regards to user flow due to the complexity of the logic, such as the following:
  - Search bar is disabled when selections are made
  - Table page is reset to the first page whenever the map<->list view is toggled
  - Table page is reset to the first page whenever the viewport is changed / the map is dragged
 ## Refs
- [Taiga User Story](https://tree.taiga.io/project/sastawia-ser-401-project-24/us/374?milestone=286959)